### PR TITLE
replace C head with CPP header

### DIFF
--- a/sift_bam_max_cov.cpp
+++ b/sift_bam_max_cov.cpp
@@ -2,7 +2,8 @@
 #include <stdio.h>
 // #include <unistd.h>
 #include <stdlib.h>
-#include <string.h>
+#include <string>
+#include <cstring>
 #include <getopt.h>
 #include <stdint.h>
 #include <limits.h>


### PR DESCRIPTION
fix compile error with GCC 10.2.0

```
g++ -std=c++11 -o _sift_bam_max_cov sift_bam_max_cov.cpp -Wall -O2 -L./htslib/build/lib/ -I./htslib/build/include -lhts
sift_bam_max_cov.cpp:17:6: error: string in namespace std does not name a type
   17 | std::string tmp_text(input_header->text, input_header->l_text);
      |      ^~~~~~
sift_bam_max_cov.cpp:16:1: note: std::string is defined in header <string>; did you forget to #include <string>?
   15 | #include "htslib/bgzf.h"
  +++ |+#include <string>
```
